### PR TITLE
Hide extra details unless --verbose is specified

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -67,10 +67,13 @@ module.exports = class Commands {
         meta += chalk.yellow(' - ' + template.description)
       }
 
-      templatesLog.push(meta + '\n' + files)
+      templatesLog.push(meta + (config.config.verbose ? '\n' + files : ''));
     }
 
-    console.log(chalk.cyan('Templates Path:'), templatesPath + '\n')
+    if (config.config.verbose) {
+      console.log(chalk.cyan('Templates Path:'), templatesPath + '\n')
+    }
+
     console.log(templatesLog.join('\n\n'))
   }
 
@@ -90,7 +93,7 @@ module.exports = class Commands {
       let questions = prompt.questionsFromVariables(variables)
 
       prompt.ask(questions, (answers) => {
-        let generator = new Generator(templateObj, answers, delimiters)
+        let generator = new Generator(config, templateObj, answers, delimiters)
 
         generator.run()
       })

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -11,7 +11,8 @@ const async = require('async')
 const isBinaryFile = require('isbinaryfile')
 
 module.exports = class Generator {
-  constructor (templateObj, data, delimiters, distPath) {
+  constructor (config, templateObj, data, delimiters, distPath) {
+    this.config = config
     this.templateObj = templateObj
     this.srcPath = templateObj.path
     this.distPath = distPath || process.cwd()
@@ -76,7 +77,7 @@ module.exports = class Generator {
   processFile (fileSrcPath, fileDistPath, cb) {
     let shortSrcPath = fileSrcPath.replace(this.srcPath + '/', '')
     let shortDistPath = fileDistPath.replace(this.distPath + '/', '')
-    let moveLog = Chalk.yellow(shortSrcPath) + Chalk.grey(' -> ') + Chalk.yellow(shortDistPath)
+    let moveLog = (this.config.config.verbose ? Chalk.yellow(shortSrcPath) + Chalk.grey(' -> ') : '') + Chalk.yellow(shortDistPath)
 
     if (!Fs.existsSync(fileDistPath)) {
       console.log(Chalk.green('Create'), moveLog)

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ const commands = new Commands()
 
 commander.version(require('../package.json').version)
 
+commander.option('--verbose', 'display verbose information', Boolean)
+
 commander
   .command('config')
   .description('Configure templates path and Handlebars delimiters')


### PR DESCRIPTION
Just right now I'm creating dozens of templates and the output of `lehm list|create` starts being hard to read due the `{{ templateVars }}` debug, etc.

This PR is for hiding those details by default, and display them only when `--verbose` option is provided.
## lehm list

With `--verbose` (previous default)
<img width="616" alt="screen shot 2016-07-29 at 2 29 03 am" src="https://cloud.githubusercontent.com/assets/206371/17241054/c5c4971c-5534-11e6-9516-ec1afa1c8c93.png">

Without `--verbose` (new default proposal)
<img width="610" alt="screen shot 2016-07-29 at 2 29 29 am" src="https://cloud.githubusercontent.com/assets/206371/17241059/cb9471f8-5534-11e6-9051-764fde7343d5.png">
## lehm create

With `--verbose` (previous default)
<img width="615" alt="screen shot 2016-07-29 at 2 30 16 am" src="https://cloud.githubusercontent.com/assets/206371/17241071/e454be50-5534-11e6-9784-78dcef4494a7.png">

Without `--verbose` (new default proposal)
<img width="615" alt="screen shot 2016-07-29 at 2 30 39 am" src="https://cloud.githubusercontent.com/assets/206371/17241073/e8e67562-5534-11e6-96d3-a8cab9d3bc5a.png">

With this behavior enabled by default I think people who wants minimal logging (whenever isn't critical) will love `lehm` too.

BTW; What you've done is exactly what I wanted from a generator. :beers:
