### PR TITLE
Parse and append templatesObj.variables too

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -14,16 +14,7 @@ module.exports = class Parser {
   parseFiles (templatesObj) {
     let retObj = {}
 
-    for (let filePath of templatesObj.files) {
-      let fullPath = path.join(templatesObj.path, filePath)
-
-      if (isBinaryFile.sync(fullPath)) {
-        continue
-      }
-
-      let content = fs.readFileSync(fullPath, 'utf8')
-      let variables = this.parseVariables(fullPath + content)
-
+    function append(variables) {
       for (let variableName in variables) {
         if (!retObj[variableName]) {
           retObj[variableName] = variables[variableName]
@@ -38,6 +29,24 @@ module.exports = class Parser {
         }
       }
     }
+
+    for (let filePath of templatesObj.files) {
+      let fullPath = path.join(templatesObj.path, filePath)
+
+      if (isBinaryFile.sync(fullPath)) {
+        continue
+      }
+
+      let content = fs.readFileSync(fullPath, 'utf8')
+      let variables = this.parseVariables(fullPath + content)
+
+      append(variables)
+    }
+
+    let extra = Array.isArray(templatesObj.variables) ? templatesObj.variables.join('') : templatesObj.variables || '';
+    let variables = this.parseVariables(extra)
+
+    append(variables)
 
     return retObj
   }


### PR DESCRIPTION
Another interesting use case, having this templates:

```
.
└── test
    ├── test.js
    ├── {{\ value\ }}
    │   └── a.txt
    ├── {{!\ baz\ =\ buzz\ #\ bazzinga\ }}{{baz}}
    │   └── b.txt
    └── {{!\ hidden\ =\ value\ #\ will\ be\ removed\ }}
        └── c.txt

4 directories, 4 files
```

And this configuration:

``` js
// test.js
module.exports = {
  name: 'Test module',
  description: 'A skeleton for a test module',
  delimiters: '{{ }}',
  ingnore: ['node_modules'],
  // proposed value example: string or array
  variables: [
    '{{! value = foo # Default value }}'
  ]
}
```

I got this output:

```
.
├── buzz
│   └── b.txt
├── c.txt
└── foo
    └── a.txt

2 directories, 3 files
```

See the different prompts/logs and spot which is more clear:
<img width="614" alt="screen shot 2016-07-29 at 3 15 21 am" src="https://cloud.githubusercontent.com/assets/206371/17242402/8ae2dffc-553c-11e6-95b6-734dab38722e.png">

IMO: while is plenty possible declare and use variables on directory names it becomes hard to understand when you read the directory tree. 🎉 

This PR will allow us to declare variable definitions within the template settings.
